### PR TITLE
some changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,8 @@ Configuration
   want to fill comments at, for example, column 70, but want a vertical rule
   at column 80 or 100 to indicate the maximum line length for code.)  The
   default behavior (showing the indicator at the fill column) is specified by
-  setting fci-rule-column to nil.
+  setting fci-rule-column to nil.  Note that this is a buffer-local variable,
+  so you can have different values for different modes.
 
 * On graphical displays the fill-column rule is drawn using a bitmap
   image.  Its color is controlled by the variable `fci-rule-color`, whose

--- a/fill-column-indicator.el
+++ b/fill-column-indicator.el
@@ -44,8 +44,9 @@
 
 ;; By default, fci-mode draws its vertical indicator at the fill column.  If
 ;; you'd like it to be drawn at another column, set `fci-rule-column' to a
-;; different value.  The default behavior is specified by setting
-;; `fci-rule-column' to nil.
+;; different value.  This variable becomes buffer-local when set, so you can
+;; have a different value for different modes.  The default behavior is
+;; specified by setting `fci-rule-column' to nil.
 
 ;; On graphical displays the fill-column rule is drawn using a bitmap
 ;; image.  Its color is controlled by the variable `fci-rule-color', whose
@@ -197,6 +198,7 @@ function `fci-mode' is run."
   :type '(choice (symbol :tag "Use the fill column" 'fill-column)
                  (integer :tag "Use a custom column"
                           :match (lambda (w val) (fci-posint-p val)))))
+(make-variable-buffer-local 'fci-rule-column)
 
 (defcustom fci-rule-color "#cccccc"
   "Color used to draw the fill-column rule.


### PR DESCRIPTION
Hi, this is like my new favorite emacs feature.  I've tried some other packages over the years that try to do this but they have been fairly clunky.  Thanks for putting it together.

Here are a few changes for your consideration:
1. Add the ability to make the ruler line dashed.  This looks a little more polished than a solid line, and more importantly is useful when working with two windows side-by-side in a single frame.  Otherwise the ruler line is visually confusing with the line marking the separation between the two windows.
2. Add a 'turn-on-fci-mode' function to unconditionally turn on the mode.  This is similar to 'turn-on-auto-fill', 'turn-on-font-lock', etc and is useful for hooks: (add-hook 'diff-mode-hook 'turn-on-fci-mode)
3. Make 'fci-rule-column' buffer-local.  This allows one to specify a different value for different modes.

Thanks
-- bart
