### PR TITLE
Autoload fci-mode and turn-on-fci-mode

### DIFF
--- a/fill-column-indicator.el
+++ b/fill-column-indicator.el
@@ -419,6 +419,7 @@ U+E000-U+F8FF, inclusive)."
 ;;; Mode Definition
 ;;; ---------------------------------------------------------------------
 
+;;;###autoload
 (define-minor-mode fci-mode
   "Toggle fci-mode on and off.
 Fci-mode indicates the location of the fill column by drawing a
@@ -465,6 +466,7 @@ on troubleshooting.)"
     (dolist (var fci-internal-vars)
       (set var nil))))
 
+;;;###autoload
 (defun turn-on-fci-mode ()
   "Turn on fci-mode unconditionally."
   (interactive)


### PR DESCRIPTION
So that in my init file I can say (add-hook 'prog-mode-hook 'turn-on-fci-mode)
without having to load the package up-front.

Would you mind submitting the new version to marmalade? I wasn't sure whether
to update the version number in the comment at the top of the file, so I didn't.

Thanks!
