### PR TITLE
Don't compile and autoload fci-osx-23-fix.el

### DIFF
--- a/fci-osx-23-fix.el
+++ b/fci-osx-23-fix.el
@@ -56,3 +56,8 @@
              '(post-command-hook fci-nextstep-23-hack 'local))
 
 (provide 'fci-osx-23-fix)
+;; Local Variables:
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; End:
+;;; fci-osx-23-fix ends here


### PR DESCRIPTION
Otherwise `byte-recompile-directory` and friends would complain on contemporary Emacsen.

You might also want to consider removing this file completely - v23 is quite outdated by now.